### PR TITLE
Pronoun support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 _site
+.ruby-version
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 
 .vscode

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem "jekyll", "~> 4.2.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
+# For MacOS users: There are some issues getting the site running without having webrick installed first. This import below is meant to resolve that.
+gem "webrick"
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -82,6 +83,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data
+  webrick
 
 BUNDLED WITH
-   2.2.15
+   2.5.10

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ hashdump.github.io
 This is the backend for https://hashdumpsecurity.org and our associated wiki
 
 Look in the **\_data** directory to modify officers and meetings.
+
+### Local Development
+
+Please consult the helpful guide on [Jekyll's website](https://jekyllrb.com/docs/installation/#guides) for local development.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,13 +16,19 @@
     <script>
         // Script to open and close sidebar
         function w3_open() {
+            document.getElementById("mySidebar").style.opacity = "1";
+            document.getElementById("myOverlay").style.opacity = "1";
             document.getElementById("mySidebar").style.display = "block";
             document.getElementById("myOverlay").style.display = "block";
         }
 
         function w3_close() {
-            document.getElementById("mySidebar").style.display = "none";
-            document.getElementById("myOverlay").style.display = "none";
+            document.getElementById("mySidebar").style.opacity = "0";
+            document.getElementById("myOverlay").style.opacity = "0";
+            setTimeout(() => {
+                document.getElementById("mySidebar").style.display = "none";
+                document.getElementById("myOverlay").style.display = "none";
+            }, 200);
         }
 
         // Modal Image Gallery

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -47,7 +47,7 @@
     <!-- Top menu on small screens -->
     <header class="w3-container w3-top w3-hide-large background-header w3-xlarge w3-padding-16 text-default">
         <span class="w3-left w3-padding">Hashdump Security</span>
-        <a href="javascript:void(0)" class="w3-right w3-button background-header" onclick="w3_open()">☰</a>
+        <p class="w3-right w3-button background-header" onclick="w3_open()">☰</p>
     </header>
 
     <!-- Overlay effect when opening sidebar on small screens -->

--- a/assets/css/hashdump.css
+++ b/assets/css/hashdump.css
@@ -69,7 +69,7 @@ body, h1, h2, h3, h4, h5 {
     }
 }
 
-.officer-list {
+.card-list {
     display: flex;
     flex-wrap: wrap;
 }

--- a/assets/css/hashdump.css
+++ b/assets/css/hashdump.css
@@ -69,6 +69,11 @@ body, h1, h2, h3, h4, h5 {
     }
 }
 
+.officer-list {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 .officer-heading {
     display: flex;
     justify-content: space-between;

--- a/assets/css/hashdump.css
+++ b/assets/css/hashdump.css
@@ -69,10 +69,35 @@ body, h1, h2, h3, h4, h5 {
     }
 }
 
-a {
+.officer-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    column-gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+
+.officer-pronouns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.pronoun-badge {
+    background-color: #0018a3;
+    color: #ffffff;
+    letter-spacing: 0.3px;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    border-radius: 1rem;
+}
+
+a, .officer-email {
     color: #0018a3;
     text-decoration: none;
     font-weight: bold;
+    margin-bottom: 0rem;
 }
 
 .social-media {
@@ -80,7 +105,7 @@ a {
     text-decoration: none;
 }
 
-a:hover
+a:hover, .officer-email:hover
 {
     color:#7ac9f9;
     text-decoration:none;

--- a/assets/css/hashdump.css
+++ b/assets/css/hashdump.css
@@ -2,6 +2,10 @@ body, h1, h2, h3, h4, h5 {
     font-family: "Raleway", sans-serif
 }
 
+#mySidebar, #myOverlay {
+    transition: linear 0.2s;
+}
+
 .w3-third img {
     padding: 5px;
     opacity: 1;

--- a/meetings.html
+++ b/meetings.html
@@ -5,7 +5,7 @@ permalink: /meetings/
 {% include header.html %}
 
 {% assign i = 0 %}
-<div class="col-md-12">
+<div class="col-md-12 card-list">
 	{% for meeting in site.data.meetings.meetings reversed%}
 		{% assign uri = '/assets/images/' | append: meeting.picture %}
 		{% assign i = i | plus: 1 %}

--- a/officers.html
+++ b/officers.html
@@ -4,7 +4,7 @@ permalink: /officers/
 {% assign title = 'Officers' %}
 {% include header.html %}
 
-<div class="col-md-12 officer-list">
+<div class="col-md-12 card-list">
 {% for member in site.data.officers.officers %}
 {% assign uri = '/assets/images/officers/' | append: member.picture %}
 	{% assign i = i | plus: 1 %}

--- a/officers.html
+++ b/officers.html
@@ -12,19 +12,28 @@ permalink: /officers/
 		<div class="col-md-12 background-foreground text-default" style="padding-right:0px;padding-left:0px" future-date="{{ meeting.date | date: '%Y/%m/%d' }}">
 			<img class="w3-circle" src={{ uri }} style="width:50%;" alt="officer">
 			<div style="padding:10px" class="background-foreground hashdump-card">
-				<h4>{{ member.name }}</h4>
+				<div class="officer-heading">
+					<h4>{{ member.name }}</h4>
+					{% if member.pronouns %}
+						<div class="officer-pronouns">
+							{% for pronoun in member.pronouns %}
+								<div class="pronoun-badge">{{ pronoun }}</div>
+							{% endfor %}
+						</div>
+					{% endif %}
+				</div>
 				<h5>{{ member.title }}</h5>
 				<p>{{ member.bio }}</p>
 				{% if member.responsibilities %}
 					<h5>Responsibilities</h5>
 					<ul>
 						{% for responsibility in member.responsibilities%}
-						<li>{{ responsibility }}</li>
+							<li>{{ responsibility }}</li>
 						{% endfor %}
 					</ul>
 				{% endif %}
 				<h5>Contact</h5>
-				<a href="mailto:{{ member.email }}" target="_top">{{ member.email }}</a>
+				<p class="officer-email" onclick="window.open(`mailto:{{ member.email | replace: '@', ' [at] '}}`.replace(' [at] ', '@'))" target="_top">{{ member.email | replace: "@", " [at] "}}</p>
 			</div>
 		</div>
 	</div>

--- a/officers.html
+++ b/officers.html
@@ -4,7 +4,7 @@ permalink: /officers/
 {% assign title = 'Officers' %}
 {% include header.html %}
 
-<div class="col-md-12">
+<div class="col-md-12 officer-list">
 {% for member in site.data.officers.officers %}
 {% assign uri = '/assets/images/officers/' | append: member.picture %}
 	{% assign i = i | plus: 1 %}


### PR DESCRIPTION
This series of updates is meant to add the following features to the website:

## Main addition

### Pronoun support in officer cards

Allows for the displaying of multi-field pronouns on the officers page.

Use a string array with field "pronouns" in `_data/officers.json` to show them in an officer's card.

## Other improvements

### Email sanitizing to prevent automated scraping

Officer emails will be replaced with [at] in place for \@. You can still click them to open an email composer.

### Quality-of-life

- Multi-column card view when there is space
- Sidebar transition-out so it's not abrupt on close