### PR TITLE
Fix meeting page headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.3)
+    rexml (3.3.6)
       strscan
     rouge (3.30.0)
     rubyzip (2.3.2)

--- a/_data/meetings.json
+++ b/_data/meetings.json
@@ -1067,7 +1067,13 @@
 			"time": "4:00 PM",
 			"title": "Intro + Large Language Models",
 			"picture": "chatgpt-ascii-art.png",
-			"summary": "Hashdump returns for our first meeting of the school year! Everett will discuss common exploits affecting large language models (LLMs) like ChatGPT and Bing Chat. Afterward, we will try to extract hidden information from an LLM in the online Gandalf activity."
+			"summary": "Hashdump returns for our first meeting of the school year! Everett will discuss common exploits affecting large language models (LLMs) like ChatGPT and Bing Chat. Afterward, we will try to extract hidden information from an LLM in the online Gandalf activity.",
+			"links": [
+				{
+					"url": "https://gandalf.lakera.ai/gandalf",
+					"name": "Gandalf"
+				}
+			]
 		},
 		{
 			"date": "September 11th, 2024",

--- a/index.html
+++ b/index.html
@@ -41,12 +41,11 @@ permalink: /
 	<hr/>
 </div>
 		
-<div class="col-md-12">
+<div class="col-md-12 clearfix">
 {% for meeting in site.data.meetings.meetings %}{% if forloop.rindex <= 3 %}
 	{% assign uri = 'assets/images/' | append: meeting.picture %}
 	{% include meeting_card.html meeting_data=meeting image_uri=uri %}
 {% endif %}{% endfor %}
-<div class="clearfix"></div>
 </div>
 
 {% include footer.html %}

--- a/meetings.html
+++ b/meetings.html
@@ -16,31 +16,28 @@ permalink: /meetings/
 
 <script>
 $(function() {
-	lowest = 0;
-	for (var fd of $('[future-date]')){
+	let today = new Date();
+	let upcoming = [];
+
+	for (let fd of $('[future-date]')){
 		meetDate = new Date($(fd).attr('future-date'));
 		meetDate.setHours(19);
 		meetDate.setMinutes(0);
-		today = new Date();
-		if ( meetDate >= today){
-			if (meetDate < lowest || lowest === 0){
-				lowest = meetDate;
-			}
+
+		if (meetDate >= today){
+			upcoming.push($(fd).detach());
 		}
 	}
-	for (var fd of $('[future-date]')){
-		meetDate = new Date($(fd).attr('future-date'));
-		meetDate.setHours(19);
-		meetDate.setMinutes(0);
-		if ( meetDate.getTime() === new Date(lowest).getTime()){
-			// $(fd).find('h5>span').addClass('w3-tag w3-round background-red');
 
-			// If we detect an upcoming meeting, we need to visually split the 
-			// meetings page into upcoming and previous meetings.
-			$(fd).after('<div class="col-md-12"><h2>Previous Meetings</h2><hr/></div>');
+	if (upcoming.length > 0) {
+		const cards = $(".card-list");
+		cards.prepend('<div class="col-md-12"><h2>Previous Meetings</h2><hr/></div>');
 
-			$(".card-list").prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
+		for (let fd of upcoming) {
+			cards.prepend(fd);
 		}
+
+		cards.prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
 	}
 });
 

--- a/meetings.html
+++ b/meetings.html
@@ -41,10 +41,6 @@ $(function() {
 
 			let cards = $(".card-list")
 			cards.prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
-
-			$('html, body').animate({
-				scrollTop: $(fd).offset().top - 100
-			},1000);
 		}
 	}
 });

--- a/meetings.html
+++ b/meetings.html
@@ -4,16 +4,11 @@ permalink: /meetings/
 {% assign title = 'Meetings' %}
 {% include header.html %}
 
-{% assign i = 0 %}
-<div class="col-md-12 card-list">
+<div class="col-md-12 card-list clearfix">
 	{% for meeting in site.data.meetings.meetings reversed%}
 		{% assign uri = '/assets/images/' | append: meeting.picture %}
 		{% assign i = i | plus: 1 %}
 		{% include meeting_card.html meeting_data=meeting image_uri=uri%}
-		{% if i == 3 %}
-			<div class="clearfix"></div>
-			{% assign i = 0 %}
-		{% endif %}
 	{% endfor %}
 </div>
 
@@ -42,22 +37,10 @@ $(function() {
 
 			// If we detect an upcoming meeting, we need to visually split the 
 			// meetings page into upcoming and previous meetings.
-			$(fd).after('<h2 class="p-3 w-100"> Previous Meetings: </h2>');
-			$(fd).after('<hr/>');
-			$(fd).after('<div class="w-100"/>');
-			$(fd).after('<div class="clearfix"></div>');
-			
-			let cards = $(".card-list")
-			cards.prepend('<h2 class="p-3 w-100"> Upcoming Meetings: </h2>');
-			cards.prepend('<hr/>');
-			cards.prepend('<div class="w-100"/>');
+			$(fd).after('<div class="col-md-12"><h2>Previous Meetings</h2><hr/></div>');
 
-			// When this happens, every `div.clearfix' needs to be pushed
-			// forward by one element, since the upcoming meeting
-			// was pulled out of the flow.
-			for (var clearfix of $('div.col-md-12 > div.clearfix')) {
-				$(clearfix).insertAfter($(clearfix).next());
-			}
+			let cards = $(".card-list")
+			cards.prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
 
 			$('html, body').animate({
 				scrollTop: $(fd).offset().top - 100

--- a/meetings.html
+++ b/meetings.html
@@ -39,8 +39,7 @@ $(function() {
 			// meetings page into upcoming and previous meetings.
 			$(fd).after('<div class="col-md-12"><h2>Previous Meetings</h2><hr/></div>');
 
-			let cards = $(".card-list")
-			cards.prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
+			$(".card-list").prepend('<div class="col-md-12"><h2>Upcoming Meetings</h2><hr/></div>');
 		}
 	}
 });

--- a/meetings.html
+++ b/meetings.html
@@ -30,9 +30,13 @@ $(function() {
 	}
 
 	if (upcoming.length > 0) {
+		// If we detect an upcoming meeting, we need to visually split the
+		// meetings page into upcoming and previous meetings.
+
 		const cards = $(".card-list");
 		cards.prepend('<div class="col-md-12"><h2>Previous Meetings</h2><hr/></div>');
 
+		// Reverse the order of upcoming meeting cards for consistency with the front page.
 		for (let fd of upcoming) {
 			cards.prepend(fd);
 		}

--- a/meetings.html
+++ b/meetings.html
@@ -47,9 +47,10 @@ $(function() {
 			$(fd).after('<div class="w-100"/>');
 			$(fd).after('<div class="clearfix"></div>');
 			
-			$(fd).before('<h2 class="p-3" display="block"> Upcoming Meetings: </h2>');
-			$(fd).before('<hr/>');
-			$(fd).before('<div class="w-100"/>');
+			let cards = $(".card-list")
+			cards.prepend('<h2 class="p-3 w-100"> Upcoming Meetings: </h2>');
+			cards.prepend('<hr/>');
+			cards.prepend('<div class="w-100"/>');
 
 			// When this happens, every `div.clearfix' needs to be pushed
 			// forward by one element, since the upcoming meeting


### PR DESCRIPTION
The header elements on https://hashdumpsecurity.org/meetings/ are currently quite broken. In this PR, I've fixed the layout issues and cleaned up some of the logic on the meeting page. I also added the link for Gandalf to one of the meeting cards.